### PR TITLE
`actionPromiseBinding` get out of sync if the action changes

### DIFF
--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -18,14 +18,16 @@ export default Ember.Component.extend({
     return this.getWithDefault(this.textState, this.get('default'));
   }),
 
-  bindActionPromise: Ember.on('init', function() {
+  bindActionPromise: Ember.on('init', Ember.observer('action', function() {
     var promisePath = '_parentView.context.' + this.get('action') + 'Promise';
     this.set('actionPromiseBinding', Ember.bind(this, 'actionPromise', promisePath));
-  }),
+  })),
 
   handleActionPromise: Ember.observer('actionPromise', function() {
-    var _this = this;
-    this.get('actionPromise').then(function() {
+    var _this = this,
+        actionPromise = this.get('actionPromise');
+    if (!actionPromise) return;
+    actionPromise.then(function() {
       _this.set('textState', 'resolved');
     }).catch(function() {
       _this.set('textState', 'rejected');


### PR DESCRIPTION
2 changes to fix `actionPromiseBinding` getting out of sync
1. run `bindActionPromise` on change to keep in sync with the `action`
2. only call `then` on the `actionPromise` if we have one
