### PR TITLE
Fixes template loading for versions greater than 37

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,13 @@ function unwatchedTree(dir) {
 }
 
 EmberCLIAsyncButton.prototype.treeFor = function treeFor(name) {
-  var treePath =  path.join('node_modules', 'ember-cli-async-button', name);
+  var treePath = path.join('node_modules', 'ember-cli-async-button');
+
+  if (name === 'templates') {
+      treePath = path.join(treePath, 'app', name);
+  } else {
+      treePath = path.join(treePath, name);
+  }
 
   if (fs.existsSync(treePath)) {
     return unwatchedTree(treePath);


### PR DESCRIPTION
This is a backwards compatible fix. The way templates were loaded was
changed by @rjackson, `template` is passed to `treeFor`, since it is
under `app` it would not be loaded previously.

If we don't care about pre-0.0.39, then the other fix for this is to
leave `treeFor` the same, and move the `templates` directory to a
sibling of `app`. If desired, I can alter this PR

@rjackson helped in the making of this PR :+1:
