### PR TITLE
Passes the button to the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember CLI Async Button
 
-[See a demo](http://emberjs.jsbin.com/vomuzexe/1)
+[See a demo](http://jsbin.com/tonap/1)
 
 ## About ##
 
@@ -28,10 +28,10 @@ given in the helper.
 ```js
 Ember.Controller.extend({
   actions: {
-    save: function() {
+    save: function(button) {
       var promise = this.get('model').save();
 
-      this.set('savePromise', promise);
+      button.set('promise', promise);
 
       promise.then(function() {
         ...
@@ -41,10 +41,9 @@ Ember.Controller.extend({
 });
 ```
 
-Make special note of `this.set('savePromise', promise);` In order for
+Make special note of `button.set('promise', promise);` In order for
 `async-button` to work correctly the promise in the action must be
-assigned to the property of `<actionName>Promise`. So if you are using
-an action named `destroyRecord` you need to assign to `destroyRecordPromise`.
+assigned to the property of `promise` on the parameter passed in.
 
 ### Options ###
 

--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
   disabled: Ember.computed.equal('textState','pending'),
 
   click: function() {
-    this.sendAction();
+    this.sendAction('action', this);
     this.set('textState', 'pending');
 
     // If this is part of a form, it will preform an HTML form
@@ -22,17 +22,12 @@ export default Ember.Component.extend({
     return this.getWithDefault(this.textState, this.get('default'));
   }),
 
-  bindActionPromise: Ember.on('init', function() {
-    var promisePath = '_parentView.context.' + this.get('action') + 'Promise';
-    this.set('actionPromiseBinding', Ember.bind(this, 'actionPromise', promisePath));
-  }),
-
-  handleActionPromise: Ember.observer('actionPromise', function() {
+  handleActionPromise: Ember.observer('promise', function() {
     var _this = this;
-    this.get('actionPromise').then(function() {
+    this.get('promise').then(function() {
       _this.set('textState', 'resolved');
     }).catch(function() {
       _this.set('textState', 'rejected');
     });
-  }),
+  })
 });


### PR DESCRIPTION
This removes the need to reach into the `_parentView` to find the
promise, and avoid naming it based on the action
