### PR TITLE
pass callback to action instead of passing the component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ember CLI Async Button
 
-[See a demo](http://jsbin.com/tonap/1)
+[See a demo](http://jsbin.com/vijen/1)
 
 ## About ##
 
@@ -28,10 +28,10 @@ given in the helper.
 ```js
 Ember.Controller.extend({
   actions: {
-    save: function(button) {
+    save: function(callback) {
       var promise = this.get('model').save();
 
-      button.set('promise', promise);
+      callback(promise);
 
       promise.then(function() {
         ...
@@ -41,9 +41,9 @@ Ember.Controller.extend({
 });
 ```
 
-Make special note of `button.set('promise', promise);` In order for
+Make special note of `callback(promise);` In order for
 `async-button` to work correctly the promise in the action must be
-assigned to the property of `promise` on the parameter passed in.
+passed back to the `callback` function that is passed in.
 
 ### Options ###
 

--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -10,7 +10,10 @@ export default Ember.Component.extend({
   disabled: Ember.computed.equal('textState','pending'),
 
   click: function() {
-    this.sendAction('action', this);
+    var _this = this;
+    this.sendAction('action', function(promise){
+      _this.set('promise', promise);
+    });
     this.set('textState', 'pending');
 
     // If this is part of a form, it will preform an HTML form


### PR DESCRIPTION
This change accomplishes 2 things...
1. allows use to just call the `callback(promise)` instead of calling `button.set('promise', promise)`
2. blocks the action from modifying other properties on the `button`.
