### PR TITLE
Allow setting the button type

### DIFF
--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -5,8 +5,9 @@ export default Ember.Component.extend({
   textState: 'default',
   classNames: ['async-button'],
   classNameBindings: ['textState'],
-  attributeBindings: ['disabled'],
+  attributeBindings: ['disabled', 'type'],
 
+  type: 'submit',
   disabled: Ember.computed.equal('textState','pending'),
 
   click: function() {

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -40,3 +40,13 @@ test('button fails', function() {
     });
   });
 });
+
+test('button type is set', function() {
+  visit('/');
+
+  andThen(function() {
+    ok(Ember.$('button.async-button[type="submit"]').length === 1);
+    ok(Ember.$('button.async-button[type="button"]').length === 1);
+    ok(Ember.$('button.async-button[type="reset"]').length === 1);
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,2 +1,4 @@
 {{input checked=rejectPromise type="checkbox" class="rejectPromise"}}
 {{async-button action="save" default="Save" pending="Saving..." resolved="Saved!" rejected="Fail!"}}
+{{async-button type="button"}}
+{{async-button type="reset"}}


### PR DESCRIPTION
This PR allows users to set the button type.

The default type for buttons is submit, which might not be what you want if you are using two async-buttons in the same form.
