### PR TITLE
Enable passing html blocks into button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ In a template use the `async-button` helper
 {{async-button action="save" default="Save" pending="Saving..."}}
 ```
 
-In the controller for the template you must create an action that matches the name 
+The component can also take a block:
+
+```handlebars
+{{#async-button action="save"}}
+  Template content.
+{{/async-button}}
+```
+
+In the controller for the template you must create an action that matches the name
 given in the helper.
 
 ```js

--- a/app/templates/components/async-button.hbs
+++ b/app/templates/components/async-button.hbs
@@ -1,1 +1,5 @@
-{{view.text}}
+{{#if template}}
+  {{yield}}
+{{else}}
+  {{view.text}}
+{{/if}}

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -45,8 +45,17 @@ test('button type is set', function() {
   visit('/');
 
   andThen(function() {
-    ok(Ember.$('button.async-button[type="submit"]').length === 1);
+    ok(Ember.$('button.async-button[type="submit"]').length === 2);
     ok(Ember.$('button.async-button[type="button"]').length === 1);
     ok(Ember.$('button.async-button[type="reset"]').length === 1);
   });
 });
+
+test('Can render a template instead', function() {
+  visit('/');
+
+  andThen(function() {
+    ok(Ember.$('button.template').text().indexOf('This is the template content.') > -1);
+  });
+});
+

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,4 +1,7 @@
 {{input checked=rejectPromise type="checkbox" class="rejectPromise"}}
-{{async-button action="save" default="Save" pending="Saving..." resolved="Saved!" rejected="Fail!"}}
+{{async-button action="save" default="Save" pending="Saving..." fulfilled="Saved!" rejected="Fail!"}}
+{{#async-button action="save" class="template"}}
+  This is the template content.
+{{/async-button}}
 {{async-button type="button"}}
 {{async-button type="reset"}}


### PR DESCRIPTION
Useful if you want to include a spinner for the pending state.

Syntax:

```
{{#async-button action="save" class="html"}}
  {{#button-state name='default'}}
    <strong>Save</strong>
  {{/button-state}}
  {{#button-state name='pending'}}
    <strong>Saving...</strong>
  {{/button-state}}
  {{#button-state name='fulfilled'}}
    <strong>Saved!</strong>
  {{/button-state}}
  {{#button-state name='rejected'}}
    <strong>Fail!</strong>
  {{/button-state}}
{{/async-button}}
```
