### PR TITLE
Add reset attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Special text  used if the promise is fulfilled. If not provided will use the `de
 
 Special text  used if the promise is rejected. If not provided will use the `default` value.
 
+#### `reset` ####
+
+Flag telling the button to reset to the default state once `resolved` or `rejected`. A typical use case is to bind this attribute with ember-data `isDirty` flag.
+
 ### Styling ###
 
 A class of `async-button` is assigned to the button. An additional

--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'button',
   textState: 'default',
+  reset: false,
   classNames: ['async-button'],
   classNameBindings: ['textState'],
   attributeBindings: ['disabled', 'type'],
@@ -24,6 +25,12 @@ export default Ember.Component.extend({
 
   text: Ember.computed('textState', 'default', 'pending', 'resolved', 'fulfilled', 'rejected', function() {
     return this.getWithDefault(this.textState, this.get('default'));
+  }),
+
+  resetObserver: Ember.observer('textState', 'reset', function(){
+    if(this.get('reset') && ['resolved', 'rejected', 'fulfilled'].contains(this.get('textState'))){
+      this.set('textState', 'default');
+    }
   }),
 
   handleActionPromise: Ember.observer('promise', function() {

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -52,6 +52,22 @@ test('button type is set', function() {
   });
 });
 
+test('button reset', function() {
+  visit('/');
+  click('button.async-button');
+
+  andThen(function() {
+    contains(find('button.async-button'), 'Saved!');
+    click('.dirtyState');
+    contains(find('button.async-button'), 'Save');
+    click('.dirtyState');
+    click('button.async-button');
+    andThen(function() {
+      contains(find('button.async-button'), 'Saved!');
+    });
+  });
+});
+
 test('Can render a template instead', function() {
   visit('/');
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,6 @@
 {{input checked=rejectPromise type="checkbox" class="rejectPromise"}}
-{{async-button action="save" default="Save" pending="Saving..." fulfilled="Saved!" rejected="Fail!"}}
+{{input checked=dirtyState type="checkbox" class="dirtyState"}}
+{{async-button action="save" default="Save" pending="Saving..." fulfilled="Saved!" rejected="Fail!" reset=dirtyState}}
 {{#async-button action="save" class="template"}}
   This is the template content.
 {{/async-button}}


### PR DESCRIPTION
Add a flag telling the button to reset to the default state once `resolved` or `rejected`. A typical use case is to bind this attribute with ember-data `isDirty` flag.
