### PR TITLE
Fix race condition when button removed before bound promise finishes

### DIFF
--- a/app/components/async-button.js
+++ b/app/components/async-button.js
@@ -36,9 +36,13 @@ export default Ember.Component.extend({
   handleActionPromise: Ember.observer('promise', function() {
     var _this = this;
     this.get('promise').then(function() {
-      _this.set('textState', 'fulfilled');
+      if (!_this.isDestroyed) {
+        _this.set('textState', 'fulfilled');
+      }
     }).catch(function() {
-      _this.set('textState', 'rejected');
+      if (!_this.isDestroyed) {
+        _this.set('textState', 'rejected');
+      }
     });
   }),
 

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -26,6 +26,78 @@ test('button resolves', function() {
   });
 });
 
+test('button bound to controller promise resolves', function() {
+  var promise = new Ember.RSVP.Promise(function(resolve, reject) {
+    resolve();
+  });
+  visit('/');
+
+  andThen(function() {
+    contains(find('#promise-bound button.async-button'), 'Save');
+    App.__container__.lookup("controller:application").set("promise", promise);
+    Ember.run.later(function() {
+      contains(find('#promise-bound button.async-button'), 'Saved!');
+    });
+  });
+});
+
+test('button bound to controller promise fails', function() {
+  var promise = new Ember.RSVP.Promise(function(resolve, reject) {
+    reject();
+  });
+  visit('/');
+
+  andThen(function() {
+    contains(find('#promise-bound button.async-button'), 'Save');
+    App.__container__.lookup("controller:application").set("promise", promise);
+    Ember.run.later(function() {
+      contains(find('#promise-bound button.async-button'), 'Fail!');
+    });
+  });
+});
+
+test('button bound to controller promise hidden on resolve', function() {
+  var resolve;
+  var controller = App.__container__.lookup("controller:application"),
+  promise = new Ember.RSVP.Promise(function(r) {
+    resolve = r;
+  });
+  controller.set('shown', true);
+  visit('/');
+
+  andThen(function() {
+    controller.set("promise", promise);
+    equal(find('#promise-bound-hides button.async-button').length, 1);
+    contains(find('#promise-bound-hides button.async-button'), 'Save');
+    controller.set('shown', false);
+    Ember.run.later(function() {
+      resolve();
+      equal(find('#promise-bound-hides button.async-button').length, 0);
+    });
+  });
+});
+
+test('button bound to controller promise hidden on reject', function() {
+  var reject;
+  var controller = App.__container__.lookup("controller:application"),
+  promise = new Ember.RSVP.Promise(function(resolve, r) {
+    reject = r;
+  });
+  controller.set('shown', true);
+  visit('/');
+
+  andThen(function() {
+    controller.set("promise", promise);
+    equal(find('#promise-bound-hides button.async-button').length, 1);
+    contains(find('#promise-bound-hides button.async-button'), 'Save');
+    controller.set('shown', false);
+    Ember.run.later(function() {
+      reject();
+      equal(find('#promise-bound-hides button.async-button').length, 0);
+    });
+  });
+});
+
 test('button fails', function() {
   visit('/');
 
@@ -46,9 +118,9 @@ test('button type is set', function() {
   visit('/');
 
   andThen(function() {
-    equal(find('button.async-button[type="submit"]').length, 2);
-    equal(find('button.async-button[type="button"]').length, 1);
-    equal(find('button.async-button[type="reset"]').length, 1);
+    equal(find('#set-type button.async-button[type="submit"]').length, 1);
+    equal(find('#set-type button.async-button[type="button"]').length, 1);
+    equal(find('#set-type button.async-button[type="reset"]').length, 1);
   });
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,5 +5,16 @@
 {{#async-button action="save" class="template"}}
   This is the template content.
 {{/async-button}}
+<div id="set-type">
+{{async-button}}
 {{async-button type="button"}}
 {{async-button type="reset"}}
+</div>
+<div id="promise-bound">
+{{async-button promiseBinding=promise default="Save" pending="Saving..." fulfilled="Saved!" rejected="Fail!"}}
+</div>
+<div id="promise-bound-hides">
+{{#if shown}}
+{{async-button promiseBinding=promise default="Save" pending="Saving..." fulfilled="Saved!" rejected="Fail!"}}
+{{/if}}
+</div>


### PR DESCRIPTION
I found a race condition when using `async-button` with a bound promise inside an if statement that turns false after promise has been assigned to the component and before the promise is resolved.

This PR fixes it.

It also includes a refactoring of one of the tests and tests from async-button using a bound promise.
