### PR TITLE
Set `positionalParams` as a static property on the class.

### DIFF
--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -5,8 +5,11 @@ var get = Ember.get;
 var getWithDefault = Ember.getWithDefault;
 var set = Ember.set;
 
-export default Ember.Component.extend({
-  positionalParams: 'params',
+var positionalParams = {
+  positionalParams: 'params'
+};
+
+var ButtonComponent = Ember.Component.extend(positionalParams, {
   layout: layout,
   tagName: 'button',
   textState: 'default',
@@ -87,3 +90,11 @@ export default Ember.Component.extend({
     if (tagName === 'a' && href === undefined) { return ''; }
   })
 });
+
+// Ember 1.13.6 will deprecate specifying `positionalParams` on the
+// instance in favor of class level property
+//
+// Having both defined keeps us compatible with Ember 1.13+ (all patch versions)
+ButtonComponent.reopenClass(positionalParams);
+
+export default ButtonComponent;


### PR DESCRIPTION
Ember 1.13.6 will be deprecating usage of `positionalParams` set within `.extend` in favor of it being set as a static property on the class itself (`.reopenClass`).

This makes both 1.13.0 - 1.13.5 and 1.13.6+ work without deprecation.

---

See the following issues/PR's for details:

* https://github.com/emberjs/ember.js/issues/11686
* https://github.com/emberjs/ember.js/pull/11934