### PR TITLE
Remove disableWhen attribute binding

### DIFF
--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -16,7 +16,7 @@ var ButtonComponent = Ember.Component.extend(positionalParams, {
   reset: false,
   classNames: ['async-button'],
   classNameBindings: ['textState'],
-  attributeBindings: ['disableWhen', 'disabled', 'type', '_href:href', 'tabindex'],
+  attributeBindings: ['disabled', 'type', '_href:href', 'tabindex'],
 
   type: 'submit',
   disabled: Ember.computed('textState','disableWhen', function() {


### PR DESCRIPTION
It makes sense to have a disableWhen argument but there doesn't seem to
be a reason to have it be a bound attribute.