### PR TITLE
Add resetAfter to delay reset

### DIFF
--- a/addon/components/async-button.js
+++ b/addon/components/async-button.js
@@ -8,7 +8,8 @@ const {
   observer,
   deprecate,
   getWithDefault,
-  Component
+  Component,
+  run: { later }
 } = Ember;
 
 let positionalParamsMixin = {
@@ -21,6 +22,7 @@ const ButtonComponent = Component.extend(positionalParamsMixin, {
   textState: 'default',
   asyncState: computed.alias('default'),
   reset: false,
+  resetAfter: 0,
   classNames: ['async-button'],
   classNameBindings: ['textState'],
   attributeBindings: ['disabled', 'type', '_href:href', 'tabindex'],
@@ -81,7 +83,7 @@ The callback for closure actions will be removed in future versions.`,
     }
 
     if (get(this, 'reset') && found) {
-      set(this, 'textState', 'default');
+      later(this, () => set(this, 'textState', 'default'), get(this, 'resetAfter'));
     }
   }),
 

--- a/tests/acceptance/button-test.js
+++ b/tests/acceptance/button-test.js
@@ -188,6 +188,19 @@ test('button reset', function() {
   });
 });
 
+test('button reset with delay', function() {
+  visit('/');
+  click('#reset-delay button');
+
+  andThen(function() {
+    contains(find('#reset-delay button'), 'Saved!');
+  });
+
+  andThen(function() {
+    contains(find('#reset-delay button'), 'Save (delay)');
+  });
+});
+
 test('Can render a template instead', function() {
   visit('/');
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -28,6 +28,10 @@
 {{/async-button}}
 </div>
 
+<div id="reset-delay">
+  {{async-button action="save" default="Save (delay)" pending="Saving..." fulfilled="Saved!" rejected="Fail!" reset=true resetAfter=3000}}
+</div>
+
 <div id="state-yield">
   {{#async-button promise=promise as |button state|}}
     {{#if state.isFulfilled}} fulfilled {{/if}}


### PR DESCRIPTION
This pull request adds a new property (defaulting to 0) `resetAfter`. This allows you to delay resetting the state to show a success message before going back to the default.

I wasn't able to come up with a passing test for this. I wasn't able to find a built in way to wait for x milliseconds in ember acceptance testing. I would be happy to fix this up with some guidance on how it should be!